### PR TITLE
fix(payments): never auto-expire IRIS pending purchases

### DIFF
--- a/backend/src/lib/payments.ts
+++ b/backend/src/lib/payments.ts
@@ -355,6 +355,15 @@ const isPendingPurchaseExpired = (purchase: PurchaseRecord, now = new Date()) =>
     return false;
   }
 
+  // IRIS bank transfers are confirmed asynchronously by EveryPay's webhook,
+  // potentially well after our 5-minute UI staleness window. Auto-failing
+  // them from a polling read path would race the webhook and silently drop
+  // a successful payment, so we never expire IRIS purchases here — only the
+  // webhook is authoritative for that flow.
+  if (purchase.payment_method_type === 'iris') {
+    return false;
+  }
+
   const expiresAt = new Date(purchase.expires_at);
   if (Number.isNaN(expiresAt.getTime())) {
     return false;

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -442,20 +442,17 @@ export const everyPayWebhookHandler = async (req: Request, res: Response) => {
       return res.status(404).json({ message: 'Purchase not found' });
     }
 
-    const resolvedPurchaseResult = await resolveExpiredPendingPurchase(purchase);
-    const resolvedPurchase = resolvedPurchaseResult.purchase;
-
-    if (!resolvedPurchase) {
-      console.error(`EveryPay webhook: purchase ${purchaseId} disappeared during processing`);
-      return res.status(404).json({ message: 'Purchase not found' });
-    }
-
-    if (resolvedPurchase.payment_status !== 'PENDING') {
+    // Do NOT apply the pending-purchase TTL here. IRIS bank transfers can be
+    // confirmed by EveryPay well after the UI-side staleness window, and the
+    // webhook is the authoritative signal that the payment actually went
+    // through. Auto-failing a still-PENDING row at this point would silently
+    // discard a successful payment.
+    if (purchase.payment_status !== 'PENDING') {
       return res.json({
         received: true,
-        status: resolvedPurchase.payment_status === 'PAID'
+        status: purchase.payment_status === 'PAID'
           ? 'already_paid'
-          : resolvedPurchase.payment_status.toLowerCase(),
+          : purchase.payment_status.toLowerCase(),
       });
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While scanning recent commits for likely bugs, the most recent payments fix (`d6da46a` — "Fixed pending hang up payment bug") introduced a 5-minute TTL on PENDING purchases that is applied on **every** read path, including:

- `everyPayWebhookHandler` (the IRIS callback from EveryPay)
- `GET /api/payments/purchase-status` (polled by `PaymentSuccess.tsx` while waiting for the bank transfer)

That TTL is reasonable for synchronous **card** payments. It is unsafe for **IRIS** bank transfers, which are confirmed asynchronously by EveryPay and can take longer than five minutes to clear.

### Failure scenario

1. User initiates an IRIS payment, gets redirected to their bank.
2. ≥5 minutes pass (waiting on the bank).
3. `PaymentSuccess` polls `/purchase-status` (or the webhook itself fires).
4. `resolveExpiredPendingPurchase` writes `payment_status = FAILED`.
5. EveryPay's real webhook arrives moments later, sees a non‑PENDING row, returns early without calling `chargeToken` / `markPurchasePaid`.
6. The user has paid, but their tier is never unlocked.

### Fix

Two minimal changes in `backend/src/`:

- `routes/payments.ts` — the webhook handler no longer runs `resolveExpiredPendingPurchase`. The webhook is authoritative; if the row is still PENDING we always process it.
- `lib/payments.ts` — `isPendingPurchaseExpired` returns `false` for `payment_method_type === 'iris'`, so polling read paths can never race the webhook. Card payments keep the original 5-minute timeout behavior.

## Reproduction

I built three small Node-based repros that mock Supabase and exercise the real compiled code paths.

### Before the fix — late IRIS webhook is dropped

```
--- repro: late IRIS webhook ---
initial row.payment_status (before webhook): PENDING (expired TTL)
webhook response: {"status":200,"body":{"received":true,"status":"failed"}}
chargeToken calls: 0
final row.payment_status: FAILED
final row.unlocked_tier: null
RESULT: FAIL — webhook dropped a real successful IRIS payment because the pending row was force-expired before processing.
```

### After the fix — webhook captures and unlocks the tier

```
EveryPay webhook: IRIS payment captured for purchase 42
--- repro: late IRIS webhook ---
initial row.payment_status (before webhook): PENDING (expired TTL)
webhook response: {"status":200,"body":{"received":true,"status":"captured"}}
chargeToken calls: 1
final row.payment_status: PAID
final row.unlocked_tier: PREMIUM
RESULT: PASS — webhook captured the payment as expected.
```

### After the fix — `/purchase-status` poll no longer races the webhook

```
--- repro #2: poll-then-webhook race for IRIS ---
initial row.payment_status: PENDING
after polling read, row.payment_status: PENDING
RESULT: PASS — IRIS purchase remained PENDING for the webhook to capture.
```

### After the fix — card timeout regression check

```
--- sanity: expired CARD purchase still gets force-failed ---
initial row.payment_status: PENDING
after resolve, didExpire: true
after resolve, row.payment_status: FAILED
RESULT: PASS — card payments still time out as before.
```

The repro scripts were not committed (kept locally during testing). Their captured output is preserved at `/opt/cursor/artifacts/repro_iris_webhook_ttl.log`.

## Testing

- ✅ Backend `tsc --noEmit`
- ✅ Backend `tsc --project tsconfig.json` (full build)
- ✅ Frontend `tsc --noEmit`
- ✅ Three custom repro scripts (late IRIS webhook, poll/webhook race, card TTL regression check) — all pass

[repro_iris_webhook_ttl.log](https://cursor.com/agents/bc-03d310af-f32b-4ffb-82f6-0b72a424b9c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro_iris_webhook_ttl.log)

## Scope

I scanned the last ~15 commits for likely high-confidence regressions. Other recent work I reviewed (landing page refactor `f13ffb2`, redirect/redirectTo persistence `8efb8a8`, lazy OpenAI client `4d45046`, decoupled IRIS/card script loading `1809778`/`84f1d39`, `tsconfig` switch to `node16` resolution) all looked behaviorally consistent and didn't reveal a smoking-gun bug, so I left them alone to keep this PR small and focused.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03d310af-f32b-4ffb-82f6-0b72a424b9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03d310af-f32b-4ffb-82f6-0b72a424b9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

